### PR TITLE
add: install cargo-chef with --locked

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ LABEL maintainer "sksat <sksat@sksat.net>"
 ARG CARGO_CHEF_VERSION="v0.1.33"
 
 RUN ( (< /etc/os-release grep "alpine") && apk add --no-cache musl-dev=1.2.2-r3 --repository="http://dl-cdn.alpinelinux.org/alpine/v3.14/main" || true) \
-  && cargo install --version "${CARGO_CHEF_VERSION#v}" cargo-chef \
+  && cargo install --version "${CARGO_CHEF_VERSION#v}" --locked cargo-chef \
   && rm -rf "${CARGO_HOME}"/registry/


### PR DESCRIPTION
- #19 でビルドがコケるなどしている
- ので`Cargo.lock`を使うようにする