### PR TITLE
disable fail-fast on build-image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -31,6 +31,7 @@ jobs:
     name: Build and Push
     needs: rust_version
     strategy:
+      fail-fast: false
       matrix:
         base_img: [buster, slim-buster, slim, bullseye, slim-bullseye, alpine]
     runs-on: ubuntu-latest


### PR DESCRIPTION
それはそれとしてalpineがコケたら他のイメージ上がらんのは違うなあ

_Originally posted by @sksat in https://github.com/sksat/cargo-chef-docker/issues/19#issuecomment-1012714206_