### PR TITLE
Run build-image workflow always

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,12 +7,6 @@ on:
     tags:
       - v*
   pull_request:
-    paths:
-      - 'rust-toolchain'
-      - 'Dockerfile'
-      - 'Dockerfile.*'
-      - 'docker-bake.hcl'
-      - '.github/workflows/build-image.yml'
 
 jobs:
   rust_version:


### PR DESCRIPTION
        別にbuild_imageは常に走っていいな．コンテナイメージ作るrepoかつpublicだし．

_Originally posted by @sksat in https://github.com/sksat/cargo-chef-docker/issues/53#issuecomment-1295859804_
      