### PR TITLE
split: cargo build option to variable

### DIFF
--- a/cargo_install.sh
+++ b/cargo_install.sh
@@ -18,7 +18,7 @@ function install_without_install() {
 	CRATE="$1"
 	VERSION="$2"
 	BUILD_OPT="--release --locked"
-	if [ -n "$3" ]; then
+	if [ $# -ge 3 ] && [ -n "$3" ]; then
 		BUILD_OPT="${BUILD_OPT} --target=$3"
 	fi
 

--- a/cargo_install.sh
+++ b/cargo_install.sh
@@ -17,10 +17,11 @@ function download_crate() {
 function install_without_install() {
 	CRATE="$1"
 	VERSION="$2"
+	BUILD_OPT="--release --locked"
 
 	download_crate "$CRATE" "$VERSION"
 	cd "${CRATE}-${VERSION}" || exit 1
-	cargo build --release --locked
+	cargo build ${BUILD_OPT}
 	cp "target/release/${CRATE}" "$CARGO_HOME/bin"
 	cd .. || exit 1
 	rm -rf "${CRATE}-${VERSION}"

--- a/cargo_install.sh
+++ b/cargo_install.sh
@@ -18,6 +18,9 @@ function install_without_install() {
 	CRATE="$1"
 	VERSION="$2"
 	BUILD_OPT="--release --locked"
+	if [ -n "$3" ]; then
+		BUILD_OPT="${BUILD_OPT} --target=$3"
+	fi
 
 	download_crate "$CRATE" "$VERSION"
 	cd "${CRATE}-${VERSION}" || exit 1


### PR DESCRIPTION
https://twitter.com/sksat_tty/status/1586369433844748295
> LLVMなんだから素直にcross buildすればええねんというのはそうなのだけど，普通の環境でビルドしてそれをCOPYだけしてくるDockerfileとそれを走らせるworkflowはダルいし気持ちが散逸してよくない．が，ここでEarthlyが救いになってくれるんですよね，と思っただけで止まっているのでやるか．

https://twitter.com/sksat_tty/status/1586371697707724800
> しかし，cargo installはどうしたものか．まあ普通にrelease buildしてパス通ってるとこに置けばいいというのはそうなのだが．流石に別archの物体をinstallってできないよな(いやできるんだろうか)

https://twitter.com/sksat_tty/status/1586372603178283016
> できなかった．nativeのccでリンクしようとするのでそこでコケる．

https://twitter.com/sksat_tty/status/1586372810171351040
> そこで便利なのがこのカスのシェルスクリプトでございます

https://github.com/sksat/cargo-chef-docker/blob/482b51e90c8faa3f82d2fb7bdd768e790bce3483/cargo_install.sh

https://twitter.com/sksat_tty/status/1586373037406162944
> 説かなりあるな．これが--targetを喰えればいいじゃんか．