### PR TITLE
Fix base rust image tag version reference

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -101,13 +101,13 @@ jobs:
       run: |
         earthly \
           +docker-${{ matrix.arch }} \
-          --BASE_TAG=${{ matrix.base_img }} --DOCKER_META_VERSION=${{ steps.meta.outputs.version }}
+          --BASE_TAG="${{ needs.rust_version.outputs.rust_version  }}-${{ matrix.base_img }}" --DOCKER_META_VERSION=${{ steps.meta.outputs.version }}
 
     - name: Set docker tag alias
       uses: ./.github/actions/action-docker-alias
       with:
         push: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-        image: ghcr.io/sksat/cargo-chef-docker:${{ matrix.base_img }}-${{ steps.meta.outputs.version }}
+        image: ghcr.io/sksat/cargo-chef-docker:${{ needs.rust_version.outputs.rust_version  }}-${{ matrix.base_img }}-${{ steps.meta.outputs.version }}
         tags_json: ${{ steps.meta.outputs.json }}
         tag_suffix: ${{ (matrix.arch != 'amd64' && matrix.arch) || '' }}
 
@@ -118,4 +118,4 @@ jobs:
     - name: Test image
       if: ${{ matrix.arch == 'amd64' }}
       run: |
-        docker run --rm ghcr.io/sksat/cargo-chef-docker:${{ matrix.base_img }}-${{ steps.meta.outputs.version }} cargo chef --version
+        docker run --rm ghcr.io/sksat/cargo-chef-docker:${{ needs.rust_version.outputs.rust_version  }}-${{ matrix.base_img }}-${{ steps.meta.outputs.version }} cargo chef --version


### PR DESCRIPTION
- #140 で発覚した
- 実は最新バージョンの Rust の docker tag を参照してしまっていた