### PR TITLE
ci: add multi-arch manifest for amd64/arm64

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -132,8 +132,6 @@ jobs:
         base_img: [slim, bullseye, slim-bullseye, bookworm, slim-bookworm]
 
     steps:
-    - uses: actions/checkout@v5.0.1
-
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5.8.0

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,6 +26,7 @@ jobs:
   build_and_push:
     name: Build and Push
     needs: rust_version
+    continue-on-error: ${{ matrix.arch == 'i686' }}
     strategy:
       fail-fast: false
       matrix:
@@ -160,6 +161,9 @@ jobs:
       with:
         username: sksat
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Create and push multi-arch manifests
       run: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -109,7 +109,7 @@ jobs:
         push: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         image: ghcr.io/sksat/cargo-chef-docker:${{ needs.rust_version.outputs.rust_version  }}-${{ matrix.base_img }}-${{ steps.meta.outputs.version }}
         tags_json: ${{ steps.meta.outputs.json }}
-        tag_suffix: ${{ (matrix.arch != 'amd64' && matrix.arch) || '' }}
+        tag_suffix: ${{ matrix.arch }}
 
     - name: Check image
       run: |
@@ -119,3 +119,57 @@ jobs:
       if: ${{ matrix.arch == 'amd64' }}
       run: |
         docker run --rm ghcr.io/sksat/cargo-chef-docker:${{ needs.rust_version.outputs.rust_version  }}-${{ matrix.base_img }}-${{ steps.meta.outputs.version }} cargo chef --version
+
+  create_manifest:
+    name: Create Multi-arch Manifest
+    needs: [rust_version, build_and_push]
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        base_img: [slim, bullseye, slim-bullseye, bookworm, slim-bookworm]
+
+    steps:
+    - uses: actions/checkout@v5.0.1
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5.8.0
+      with:
+        images: |
+          ghcr.io/${{ github.repository }},enable=true
+          sksat/${{ github.event.repository.name }},enable=true
+        flavor: |
+          latest=auto
+          suffix=-${{ needs.rust_version.outputs.rust_version }}-${{ matrix.base_img }},onlatest=false
+          suffix=-${{ matrix.base_img }},onlatest=true
+        tags: |
+          type=sha
+          type=raw,value=${{ needs.rust_version.outputs.rust_version }},enable={{is_default_branch}}
+
+    - name: Login to ghcr.io
+      uses: docker/login-action@v3.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v3.6.0
+      with:
+        username: sksat
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Create and push multi-arch manifests
+      run: |
+        TAGS=$(cat <<'EOF'
+        ${{ steps.meta.outputs.tags }}
+        EOF
+        )
+        for tag in ${TAGS}; do
+          echo "Creating manifest for ${tag}"
+          docker buildx imagetools create -t "${tag}" \
+            "${tag}-amd64" \
+            "${tag}-arm64"
+        done


### PR DESCRIPTION
## Summary
- Add `create_manifest` job that creates multi-arch manifest lists combining amd64 and arm64 variants under the same tag
- Apply arch suffix to all architectures including amd64 for consistency

Currently, unqualified tags (e.g. `1.90.0-bookworm`) point to amd64-only images. On arm64 devices like Apple Silicon Macs, pulling these tags results in amd64 images running under emulation (Rosetta).

With this change, `docker pull ghcr.io/sksat/cargo-chef-docker:1.90.0-bookworm` will automatically select the correct architecture based on the host platform.

### Tag structure after this change
| Tag | Content |
|---|---|
| `:1.90.0-bookworm` | Multi-arch manifest (amd64 + arm64) |
| `:1.90.0-bookworm-amd64` | amd64 only |
| `:1.90.0-bookworm-arm64` | arm64 only |
| `:1.90.0-bookworm-i686` | i686 only |

### Backwards compatibility
The manifest list replaces the existing single-arch tag, but since the amd64 image is included in the manifest, existing amd64 users get the exact same image.

### Note on i686
i686 builds are marked as `continue-on-error` so that failures do not block multi-arch manifest creation, which only requires amd64 and arm64 images. i686 images are not included in the multi-arch manifest and remain available via their `-i686` suffixed tags as before.

### Verified on fork
Tested on `ghcr.io/cappyzawa/cargo-chef-docker` with Apple Silicon Mac:
- `ghcr.io/sksat/cargo-chef-docker:1.90.0-bullseye` → pulled **amd64** (current, no multi-arch)
- `ghcr.io/cappyzawa/cargo-chef-docker:1.90.0-bullseye` → pulled **arm64** (with multi-arch manifest)